### PR TITLE
Correcting the link to the email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ src="https://img.shields.io/twitter/follow/crazychickendev?label=Follow%20me&sty
 
 - 💬 Ask me about **Gadgets, Android Rom Development, JavaScript, Embedded Systems, Robotics and Cyber-Security**
 
-- 📫 You can reach me **[here](dannychukz15@gmail.com)**
+- 📫 You can reach me **[here](mailto:dannychukz15@gmail.com)**
 
 - ⚡ Fun fact **I love music:headphones: and dogs:dog:**
 


### PR DESCRIPTION
Hello, the previous email link did not work properly and was referring to ``https://github.com/CrazyChickenDev/CrazyChickenDev/blob/master/dannychukz15@gmail.com``. I fixed this by setting link as ``mailto:dannychukz15@gmail.com``.